### PR TITLE
Fix association to delete shelter having pets

### DIFF
--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -5,7 +5,7 @@ class Shelter < ApplicationRecord
                         :state,
                         :zip
   
-  has_many :pets
+  has_many :pets, dependent: :destroy
 
   def pet_count
     pets.count

--- a/spec/features/shelters/shelter_delete_spec.rb
+++ b/spec/features/shelters/shelter_delete_spec.rb
@@ -28,5 +28,43 @@ RSpec.describe "As a visitor", type: :feature do
       expect(page).not_to have_content(shelter1.name)
       expect(page).to have_content(shelter2.name)
     end
+    
+    it "button will delete shelter that has pets" do
+      shelter1 = Shelter.create!(name: "Burt's Barn",
+                                 address: "123 Sesame Street",
+                                 city: "New York",
+                                 state: "NY",
+                                 zip: "12345")
+      pet1 = shelter1.pets.create!(image: "https://assets.change.org/photos/3/yk/di/kLYkdIaPKknZpoD-800x450-noPad.jpg?1519383791",
+                                   name: "Penelope",
+                                   approx_age: 1,
+                                   sex: "female")
+      pet2 = shelter1.pets.create!(image: "https://external-preview.redd.it/P4X2K5llPbMkRkmFkycSPdDGAp051xJl0UF50bZRId4.jpg?auto=webp&s=5231b2f36d623b3258d36adbfbaf9be305f0d419",
+                                   name: "Petey",
+                                   approx_age: 1,
+                                   sex: "male")
+
+      visit "/shelters"
+      
+      expect(page).to have_content(shelter1.name)
+      
+      visit "/pets"
+      
+      expect(page).to have_content(pet1.name)
+      expect(page).to have_content(pet2.name)
+      
+      visit "/shelters/#{shelter1.id}"
+
+      click_button 'Delete Shelter'
+
+      visit "/shelters"
+      
+      expect(page).not_to have_content(shelter1.name)
+
+      visit "/pets"
+      
+      expect(page).not_to have_content(pet1.name)
+      expect(page).not_to have_content(pet2.name)
+    end
   end
 end


### PR DESCRIPTION
Add `dependent: :destroy` to Shelter model to delete Pets before deleting Shelter